### PR TITLE
provide link to redirect to new doc location

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,6 @@ All hardware designs and products you can find in this repository is licensed un
 [![Video](http://img.youtube.com/vi/-SJbdPvgQnE/0.jpg)](https://www.youtube.com/watch?v=-SJbdPvgQnE "Video")
 
 [GitHub Project](https://github.com/SensorsIot/SuperPower)
+
+[Documentation Website](https://superpower.github.io/)
+

--- a/sphinx/README.md
+++ b/sphinx/README.md
@@ -1,58 +1,7 @@
-Sphinx how to
-=============
+Sphinx
+======
 
+This websites documentation has moved to, more details on "This Website How to" section from this link
 
-## Contribute to documentation
-Sphinx is a python module that generates this website, it is possible to run it locally with the following commands
+https://superpower.github.io/
 
-    cd sphinx/
-    pip install -r requirements.txt
-    make html
-
-Note : `requirements.txt` contain install versions of `Sphinx`, readthedocs theme `sphinx-rtd-theme` and other extension.
-This file is important to reproduce the same result on each generation, especially on readthedocs hosting account where it can be pointed out in the configuration.
-
-## View generated website locally
-As sphinx generates a static website, it might be enough for some browsers to open the index file `sphinx\_build\html\index.html`
-
-or any local webserver can be used, as example here VSCode plugin :
-
-* in VSCode install LiveServer Plugin
-* open in VSCode the file : `sphinx\_build\html\index.html`
-* click "Go Live" from the LiveServer Plugin
-
-## View the generated website online
-
-readthedocs hosting link : [https://superpower.readthedocs.io/en/latest/](https://superpower.readthedocs.io/en/latest/)
-
-## Create your own sphinx project
-
-    pip install sphinx
-    sphinx-quickstart
-
-the last steps creates the documentation source from which the main file `index.rst`
-
-Getting started with sphinx from readthedocs : [getting-started-with-sphinx](https://docs.readthedocs.io/en/stable/intro/getting-started-with-sphinx.html)
-
-Sphinx official documentation : [https://www.sphinx-doc.org/en/master/](https://www.sphinx-doc.org/en/master/)
-
-## Optional use virtual env
-in order not to conflict between existing python modules on the system and the ones used in this project, it is highly recommended to use a virtual environment
-
-    >python -m venv venv
-    >venv\Scripts\activate.bat
-
-more about virtual environments [tutorial](https://docs.python.org/3/tutorial/venv.html)
-
-## Get started writing reSructuredText
-* Question : Why do I have to learn yet another markup format ? sphinx support github's .md why not just use that ?
-
-* Answer : md Markdown is designed for a single page document. While rts (reStructured) is designed for a hierarchical structure with cross-references
-
-sphinx quick start : [https://www.sphinx-doc.org/en/master/usage/quickstart.html](https://www.sphinx-doc.org/en/master/usage/quickstart.html)
-
-Cheat Sheet:  [https://sphinx-tutorial.readthedocs.io/cheatsheet/](https://sphinx-tutorial.readthedocs.io/cheatsheet/)
-
-docutils rts : [https://docutils.sourceforge.io/rst.html](https://docutils.sourceforge.io/rst.html)
-
-docutils rts quick ref : [https://docutils.sourceforge.io/docs/user/rst/quickref.html](https://docutils.sourceforge.io/docs/user/rst/quickref.html)

--- a/sphinx/index.rst
+++ b/sphinx/index.rst
@@ -3,45 +3,9 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Welcome to SuperPower's documentation!
-======================================
+The SuperPower's documentation has moved
+========================================
 
-.. toctree::
-   :maxdepth: 2
-   :caption: Project
-
-   project/README.md
-   project/guidelines.rst
-   project/licence.rst
+https://superpower.github.io/
 
 
-.. toctree::
-   :maxdepth: 2
-   :caption: ESP32 Solar
-
-   uc/overview.rst
-   uc/original/overview.rst
-   uc/low/overview.rst
-   uc/requirements.rst
-   uc/development.md
-
-.. toctree::
-   :maxdepth: 2
-   :caption: Raspi Power pack
-
-   rpi/overview.md
-
-.. toctree::
-   :maxdepth: 2
-   :caption: Common
-
-   README.md
-   uc/design.rst
-
-
-Indices and tables
-==================
-
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`


### PR DESCRIPTION
As it starts to get confusing with the old and new doc locations, and in order not to create a cut, in an intermediary step I would keep the old doc but provide a link to the new one.